### PR TITLE
HTML Validation Fixes

### DIFF
--- a/data/i18n.json
+++ b/data/i18n.json
@@ -1,5 +1,5 @@
 {
-  "en_us": {
+  "en": {
     "bookYPos": 450,
     "captionSize": 41,
     "captionYPos": 500,
@@ -43,7 +43,7 @@
     "titleSize": 58,
     "titleYPos": 405
   },
-  "zh_tw": {
+  "zh-Hant": {
     "bookYPos": 450,
     "captionSize": 41,
     "captionYPos": 500,
@@ -87,7 +87,7 @@
     "titleSize": 58,
     "titleYPos": 405
   },
-  "zh_cn": {
+  "zh-Hans": {
     "bookYPos": 450,
     "captionSize": 41,
     "captionYPos": 500,
@@ -131,7 +131,7 @@
     "titleSize": 58,
     "titleYPos": 405
   },
-  "jp": {
+  "ja": {
     "bookYPos": 450,
     "captionSize": 41,
     "captionYPos": 500,

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
     <a href="jp.html">日本語</a>
     <a href="zh_tw.html">繁體中文</a>
     <a href="zh_cn.html">简体中文</a>
-    <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+    <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' alt='Buy Me a Coffee at ko-fi.com' /></a>
   </footer>
   <div id="deletePrompt" class="hidden">
     <div>

--- a/index.html
+++ b/index.html
@@ -146,19 +146,19 @@
 
         <div>
           <label>Type</label>
-          <input type="radio" name="stdialogue" value="dialogue" checked>
-          <label>Dialogue</label>
-          <input type="radio" name="stdialogue" value="intro">
-          <label>Intro</label>
-          <input type="radio" name="stdialogue" value="caption">
-          <label>Caption</label>
+          <input type="radio" name="stdialogue" value="dialogue" id="std-dialogue" checked>
+          <label for="std-dialogue">Dialogue</label>
+          <input type="radio" name="stdialogue" value="intro" id="std-intro">
+          <label for="std-intro">Intro</label>
+          <input type="radio" name="stdialogue" value="caption" id="std-caption">
+          <label for="std-caption">Caption</label>
           <br>
-          <input type="radio" name="stdialogue" value="full">
-          <label>Full Screen</label>
-          <input type="radio" name="stdialogue" value="narration">
-          <label>Narration</label>
-          <input type="radio" name="stdialogue" value="book">
-          <label>Book</label>
+          <input type="radio" name="stdialogue" value="full" id="std-full">
+          <label for="std-full">Full Screen</label>
+          <input type="radio" name="stdialogue" value="narration" id="std-narration">
+          <label for="std-narration">Narration</label>
+          <input type="radio" name="stdialogue" value="book" id="std-book">
+          <label for="std-book">Book</label>
         </div>
 
         <div>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 </head>
 <body>
   <h1>Dragalia Lost Dialogue Screen Generator</h1>
-  <canvas id="preview" width="250px" height="445px"></canvas>
+  <canvas id="preview" width="250" height="445"></canvas>
   <section>
       <div id="uploadArea" class="settings">
 
@@ -221,7 +221,7 @@
 
       </div>
   </section>
-  <canvas id="editor" width="750px" height="1334px" class="hidden"></canvas>
+  <canvas id="editor" width="750" height="1334" class="hidden"></canvas>
   <footer>
     <iframe src="https://store.steampowered.com/widget/1764410/" frameborder="0" height="190" style='width:100%;max-width:646px;'></iframe>
     <p>(Sorry for the shameless self promotion)</p>

--- a/index.html
+++ b/index.html
@@ -146,18 +146,18 @@
 
         <div>
           <label>Type</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="dialogue" checked>
+          <input type="radio" name="stdialogue" value="dialogue" checked>
           <label>Dialogue</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="intro">
+          <input type="radio" name="stdialogue" value="intro">
           <label>Intro</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="caption">
+          <input type="radio" name="stdialogue" value="caption">
           <label>Caption</label>
           <br>
-          <input type="radio" autocomplete="off" name="stdialogue" value="full">
+          <input type="radio" name="stdialogue" value="full">
           <label>Full Screen</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="narration">
+          <input type="radio" name="stdialogue" value="narration">
           <label>Narration</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="book">
+          <input type="radio" name="stdialogue" value="book">
           <label>Book</label>
         </div>
 
@@ -168,9 +168,9 @@
           <input type="radio" id="jp" name="font" value="ja">
           <label for="jp">日本語</label>
           <input type="radio" id="zh_tw" name="font" value="zh-Hant">
-          <label for="cn">繁體中文</label>
+          <label for="zh_tw">繁體中文</label>
           <input type="radio" id="zh_cn" name="font" value="zh-Hans">
-          <label for="cn">简体中文</label>
+          <label for="zh_cn">简体中文</label>
         </div>
 
         <div>

--- a/index.html
+++ b/index.html
@@ -163,13 +163,13 @@
 
         <div>
           <label>Font</label>
-          <input type="radio" id="en" name="font" value="en_us" checked>
+          <input type="radio" id="en" name="font" value="en" checked>
           <label for="en">English</label>
-          <input type="radio" id="jp" name="font" value="jp">
+          <input type="radio" id="jp" name="font" value="ja">
           <label for="jp">日本語</label>
-          <input type="radio" id="zh_tw" name="font" value="zh_tw">
+          <input type="radio" id="zh_tw" name="font" value="zh-Hant">
           <label for="cn">繁體中文</label>
-          <input type="radio" id="zh_cn" name="font" value="zh_cn">
+          <input type="radio" id="zh_cn" name="font" value="zh-Hans">
           <label for="cn">简体中文</label>
         </div>
 
@@ -228,10 +228,10 @@
     All characters/images belong to Cygames and Nintendo /
     <a href="https://github.com/chaosspam/DLDialogueScreenGenerator">Github</a>
     /
-    <a href="/DLDialogueScreenGenerator/">English</a>
-    <a href="/DLDialogueScreenGenerator/jp.html">日本語</a>
-    <a href="/DLDialogueScreenGenerator/zh_tw.html">繁體中文</a>
-    <a href="/DLDialogueScreenGenerator/zh_cn.html">简体中文</a>
+    <a href="index.html">English</a>
+    <a href="jp.html">日本語</a>
+    <a href="zh_tw.html">繁體中文</a>
+    <a href="zh_cn.html">简体中文</a>
     <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
   </footer>
   <div id="deletePrompt" class="hidden">

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
 
         <div>
           <label>Dialogue Text</label>
-          <textarea name="" id="dialogue" cols="45" rows="5">Hey there!&#13;&#10;Enjoying the Dialogue Screen Generator?&#13;&#10;If you want to support this project,&#13;&#10;Please consider buying Chao's new game!</textarea>
+          <textarea id="dialogue" cols="45" rows="5">Hey there!&#13;&#10;Enjoying the Dialogue Screen Generator?&#13;&#10;If you want to support this project,&#13;&#10;Please consider buying Chao's new game!</textarea>
         </div>
 
         <div>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en_us">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/jp.html
+++ b/jp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="jp">
+<html lang="ja">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/jp.html
+++ b/jp.html
@@ -141,7 +141,7 @@
 
         <div>
           <label>文章</label>
-          <textarea name="" id="dialogue" cols="45" rows="5">よーし、(夏){なつ}の(思){おも}い(出){で}をたくさん(作){つく}って、&#13;&#10;(絵){え}にしましょう！</textarea>
+          <textarea id="dialogue" cols="45" rows="5">よーし、(夏){なつ}の(思){おも}い(出){で}をたくさん(作){つく}って、&#13;&#10;(絵){え}にしましょう！</textarea>
         </div>
 
         <div>

--- a/jp.html
+++ b/jp.html
@@ -33,7 +33,7 @@
 </head>
 <body>
   <h1>ドラガリストーリー画面メーカー</h1>
-  <canvas id="preview" width="250px" height="445px"></canvas>
+  <canvas id="preview" width="250" height="445"></canvas>
   <section>
       <div id="uploadArea" class="settings">
 
@@ -221,7 +221,7 @@
 
       </div>
   </section>
-  <canvas id="editor" width="750px" height="1334px" class="hidden"></canvas>
+  <canvas id="editor" width="750" height="1334" class="hidden"></canvas>
   <footer>
     当サイトに記載されている写真・イラストの著作権はCygames/任天堂に帰属します /
     <a href="https://github.com/chaosspam/DLDialogueScreenGenerator">Github</a>

--- a/jp.html
+++ b/jp.html
@@ -146,18 +146,18 @@
 
         <div>
           <label>タイプ</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="dialogue" checked>
+          <input type="radio" name="stdialogue" value="dialogue" checked>
           <label>会話</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="intro">
+          <input type="radio" name="stdialogue" value="intro">
           <label>カットイン</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="caption">
+          <input type="radio" name="stdialogue" value="caption">
           <label>タイトル</label>
           <br>
-          <input type="radio" autocomplete="off" name="stdialogue" value="full">
+          <input type="radio" name="stdialogue" value="full">
           <label>フルアート</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="narration">
+          <input type="radio" name="stdialogue" value="narration">
           <label>ナレーション</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="book">
+          <input type="radio" name="stdialogue" value="book">
           <label>本</label>
         </div>
 
@@ -168,9 +168,9 @@
           <input type="radio" id="jp" name="font" value="ja" checked>
           <label for="jp">日本語</label>
           <input type="radio" id="zh_tw" name="font" value="zh-Hant">
-          <label for="cn">繁體中文</label>
+          <label for="zh_tw">繁體中文</label>
           <input type="radio" id="zh_cn" name="font" value="zh-Hans">
-          <label for="cn">简体中文</label>
+          <label for="zh_cn">简体中文</label>
         </div>
 
         <div>

--- a/jp.html
+++ b/jp.html
@@ -230,7 +230,7 @@
     <a href="jp.html">日本語</a>
     <a href="zh_tw.html">繁體中文</a>
     <a href="zh_cn.html">简体中文</a>
-    <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+    <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' alt='Buy Me a Coffee at ko-fi.com' /></a>
   </footer>
   <div id="deletePrompt" class="hidden">
     <div>

--- a/jp.html
+++ b/jp.html
@@ -146,19 +146,19 @@
 
         <div>
           <label>タイプ</label>
-          <input type="radio" name="stdialogue" value="dialogue" checked>
-          <label>会話</label>
-          <input type="radio" name="stdialogue" value="intro">
-          <label>カットイン</label>
-          <input type="radio" name="stdialogue" value="caption">
-          <label>タイトル</label>
+          <input type="radio" name="stdialogue" value="dialogue" id="std-dialogue" checked>
+          <label for="std-dialogue">会話</label>
+          <input type="radio" name="stdialogue" value="intro" id="std-intro">
+          <label for="std-intro">カットイン</label>
+          <input type="radio" name="stdialogue" value="caption" id="std-caption">
+          <label for="std-caption">タイトル</label>
           <br>
-          <input type="radio" name="stdialogue" value="full">
-          <label>フルアート</label>
-          <input type="radio" name="stdialogue" value="narration">
-          <label>ナレーション</label>
-          <input type="radio" name="stdialogue" value="book">
-          <label>本</label>
+          <input type="radio" name="stdialogue" value="full" id="std-full">
+          <label for="std-full">フルアート</label>
+          <input type="radio" name="stdialogue" value="narration" id="std-narration">
+          <label for="std-narration">ナレーション</label>
+          <input type="radio" name="stdialogue" value="book" id="std-book">
+          <label for="std-book">本</label>
         </div>
 
         <div>

--- a/jp.html
+++ b/jp.html
@@ -165,11 +165,11 @@
           <label>フォント</label>
           <input type="radio" id="en" name="font" value="en">
           <label for="en">English</label>
-          <input type="radio" id="jp" name="font" value="jp" checked>
+          <input type="radio" id="jp" name="font" value="ja" checked>
           <label for="jp">日本語</label>
-          <input type="radio" id="zh_tw" name="font" value="zh_tw">
+          <input type="radio" id="zh_tw" name="font" value="zh-Hant">
           <label for="cn">繁體中文</label>
-          <input type="radio" id="zh_cn" name="font" value="zh_cn">
+          <input type="radio" id="zh_cn" name="font" value="zh-Hans">
           <label for="cn">简体中文</label>
         </div>
 
@@ -226,10 +226,10 @@
     当サイトに記載されている写真・イラストの著作権はCygames/任天堂に帰属します /
     <a href="https://github.com/chaosspam/DLDialogueScreenGenerator">Github</a>
     /
-    <a href="/DLDialogueScreenGenerator/">English</a>
-    <a href="/DLDialogueScreenGenerator/jp.html">日本語</a>
-    <a href="/DLDialogueScreenGenerator/zh_tw.html">繁體中文</a>
-    <a href="/DLDialogueScreenGenerator/zh_cn.html">简体中文</a>
+    <a href="index.html">English</a>
+    <a href="jp.html">日本語</a>
+    <a href="zh_tw.html">繁體中文</a>
+    <a href="zh_cn.html">简体中文</a>
     <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
   </footer>
   <div id="deletePrompt" class="hidden">

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@
 
   // Localization
   let i18n;
-  let pageLang = "en_us";
+  let pageLang = "en";
 
   // Screen drawing data
   const furiganaSize = 15;
@@ -43,9 +43,9 @@
       addLayer(i18n[pageLang].loc.portrait, i18n[pageLang].loc.defaultPortraitSrc);
       // Wait for fonts to load before drawing
       await document.fonts.load("30px dragalialosten");
-      await document.fonts.load("30px dragalialostjp");
-      await document.fonts.load("30px dragalialostzh_tw");
-      await document.fonts.load("30px dragalialostzh_cn");
+      await document.fonts.load("30px dragalialostja");
+      await document.fonts.load("30px dragalialostzh-Hans");
+      await document.fonts.load("30px dragalialostzh-Hant");
       // Draw dialogue screen
       await drawDialogueScreen();
       // Fetch background and portrait data
@@ -118,10 +118,10 @@
       textures.fullscreen = await loadImage("images/fullscreen.png");
       textures.introBack = await loadImage("images/introBack.png");
       textures.introBar = await loadImage("images/introBar.png");
-      textures.skipjp = await loadImage("images/skipjp.png");
-      textures.skipzh_tw = await loadImage("images/skipcn.png");
-      textures.skipzh_cn = await loadImage("images/skipcn.png");
-      textures.skipen_us = await loadImage("images/skipen_us.png");
+      textures.skipja = await loadImage("images/skipjp.png");
+      textures['skipzh-Hant'] = await loadImage("images/skipcn.png");
+      textures['skipzh-Hans'] = await loadImage("images/skipcn.png");
+      textures.skipen= await loadImage("images/skipen_us.png");
       textures.loaded = true;
     }
   }
@@ -178,7 +178,7 @@
 
     ctx.drawImage(bar, 0, 0);
     // If language is not English, we draw the skip button in other language
-    if(lang !== "en_us") {
+    if(lang !== "en") {
       ctx.drawImage(textures["skip" + lang], 0, 0);
     }
 

--- a/style.css
+++ b/style.css
@@ -1,27 +1,27 @@
 /* Font face for dialogue text */
 @font-face {
-  font-family: 'dragalialosten_us';
+  font-family: 'dragalialosten';
   src: url('dragalialosten.ttf');
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'dragalialostjp';
+  font-family: 'dragalialostja';
   src: url('dragalialostjp.otf');
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'dragalialostzh_tw';
+  font-family: 'dragalialostzh-Hant';
   src: url('dragalialostzh_tw.ttf');
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'dragalialostzh_cn';
+  font-family: 'dragalialostzh-Hans';
   src: url('dragalialostzh_cn.ttf');
   font-weight: 400;
   font-style: normal;

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -33,7 +33,7 @@
 </head>
 <body>
   <h1>龙约对话画面生成器</h1>
-  <canvas id="preview" width="250px" height="445px"></canvas>
+  <canvas id="preview" width="250" height="445"></canvas>
   <section>
       <div id="uploadArea" class="settings">
 
@@ -220,7 +220,7 @@
 
       </div>
   </section>
-  <canvas id="editor" width="750px" height="1334px" class="hidden"></canvas>
+  <canvas id="editor" width="750" height="1334" class="hidden"></canvas>
   <footer>
     角色/图像均为Cygames/任天堂所有 /
     <a href="https://github.com/chaosspam/DLDialogueScreenGenerator">Github</a>

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -164,11 +164,11 @@
           <label>字型</label>
           <input type="radio" id="en" name="font" value="en">
           <label for="en">English</label>
-          <input type="radio" id="jp" name="font" value="jp">
-          <label for="jp">日本语</label>
-          <input type="radio" id="zh_tw" name="font" value="zh_tw">
-          <label for="cn">繁体中文</label>
-          <input type="radio" id="zh_cn" name="font" value="zh_cn" checked>
+          <input type="radio" id="jp" name="font" value="ja">
+          <label for="jp">日本語</label>
+          <input type="radio" id="zh_tw" name="font" value="zh-Hant">
+          <label for="cn">繁體中文</label>
+          <input type="radio" id="zh_cn" name="font" value="zh-Hans" checked>
           <label for="cn">简体中文</label>
         </div>
 
@@ -225,10 +225,10 @@
     角色/图像均为Cygames/任天堂所有 /
     <a href="https://github.com/chaosspam/DLDialogueScreenGenerator">Github</a>
     /
-    <a href="/DLDialogueScreenGenerator/">English</a>
-    <a href="/DLDialogueScreenGenerator/jp.html">日本語</a>
-    <a href="/DLDialogueScreenGenerator/zh_tw.html">繁體中文</a>
-    <a href="/DLDialogueScreenGenerator/zh_cn.html">简体中文</a>
+    <a href="index.html">English</a>
+    <a href="jp.html">日本語</a>
+    <a href="zh_tw.html">繁體中文</a>
+    <a href="zh_cn.html">简体中文</a>
     <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
   </footer>
   <div id="deletePrompt" class="hidden">

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -229,7 +229,7 @@
     <a href="jp.html">日本語</a>
     <a href="zh_tw.html">繁體中文</a>
     <a href="zh_cn.html">简体中文</a>
-    <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+    <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' alt='Buy Me a Coffee at ko-fi.com' /></a>
   </footer>
   <div id="deletePrompt" class="hidden">
     <div>

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -145,18 +145,18 @@
 
         <div>
           <label>对话类型</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="dialogue" checked>
+          <input type="radio" name="stdialogue" value="dialogue" checked>
           <label>一般</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="intro">
+          <input type="radio" name="stdialogue" value="intro">
           <label>进场</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="caption">
+          <input type="radio" name="stdialogue" value="caption">
           <label>标题</label>
           <br>
-          <input type="radio" autocomplete="off" name="stdialogue" value="full">
+          <input type="radio" name="stdialogue" value="full">
           <label>全萤幕</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="narration">
+          <input type="radio" name="stdialogue" value="narration">
           <label>叙述</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="book">
+          <input type="radio" name="stdialogue" value="book">
           <label>书</label>
         </div>
 
@@ -167,9 +167,9 @@
           <input type="radio" id="jp" name="font" value="ja">
           <label for="jp">日本語</label>
           <input type="radio" id="zh_tw" name="font" value="zh-Hant">
-          <label for="cn">繁體中文</label>
+          <label for="zh_tw">繁體中文</label>
           <input type="radio" id="zh_cn" name="font" value="zh-Hans" checked>
-          <label for="cn">简体中文</label>
+          <label for="zh_cn">简体中文</label>
         </div>
 
         <div>

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -140,7 +140,7 @@
 
         <div>
           <label>对话内容</label>
-          <textarea name="" id="dialogue" cols="45" rows="5">好～人家要创造好多夏天的回忆，&#13;&#10;然后把它们全部用画记录下来！</textarea>
+          <textarea id="dialogue" cols="45" rows="5">好～人家要创造好多夏天的回忆，&#13;&#10;然后把它们全部用画记录下来！</textarea>
         </div>
 
         <div>

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -145,19 +145,19 @@
 
         <div>
           <label>对话类型</label>
-          <input type="radio" name="stdialogue" value="dialogue" checked>
-          <label>一般</label>
-          <input type="radio" name="stdialogue" value="intro">
-          <label>进场</label>
-          <input type="radio" name="stdialogue" value="caption">
-          <label>标题</label>
+          <input type="radio" name="stdialogue" value="dialogue" id="std-dialogue" checked>
+          <label for="std-dialogue">一般</label>
+          <input type="radio" name="stdialogue" value="intro" id="std-intro">
+          <label for="std-intro">进场</label>
+          <input type="radio" name="stdialogue" value="caption" id="std-caption">
+          <label for="std-caption">标题</label>
           <br>
-          <input type="radio" name="stdialogue" value="full">
-          <label>全萤幕</label>
-          <input type="radio" name="stdialogue" value="narration">
-          <label>叙述</label>
-          <input type="radio" name="stdialogue" value="book">
-          <label>书</label>
+          <input type="radio" name="stdialogue" value="full" id="std-full">
+          <label for="std-full">全萤幕</label>
+          <input type="radio" name="stdialogue" value="narration" id="std-narration">
+          <label for="std-narration">叙述</label>
+          <input type="radio" name="stdialogue" value="book" id="std-book">
+          <label for="std-book">书</label>
         </div>
 
         <div>

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh_cn">
+<html lang="zh-Hans">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh_tw">
+<html lang="zh-Hant">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -140,7 +140,7 @@
 
         <div>
           <label>對話內容</label>
-          <textarea name="" id="dialogue" cols="45" rows="5">好～人家要創造好多夏天的回憶，&#13;&#10;然後把它們全部用畫記錄下來！</textarea>
+          <textarea id="dialogue" cols="45" rows="5">好～人家要創造好多夏天的回憶，&#13;&#10;然後把它們全部用畫記錄下來！</textarea>
         </div>
 
         <div>

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -229,7 +229,7 @@
     <a href="jp.html">日本語</a>
     <a href="zh_tw.html">繁體中文</a>
     <a href="zh_cn.html">简体中文</a>
-    <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+    <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' alt='Buy Me a Coffee at ko-fi.com' /></a>
   </footer>
   <div id="deletePrompt" class="hidden">
     <div>

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -164,11 +164,11 @@
           <label>字型</label>
           <input type="radio" id="en" name="font" value="en">
           <label for="en">English</label>
-          <input type="radio" id="jp" name="font" value="jp">
+          <input type="radio" id="jp" name="font" value="ja">
           <label for="jp">日本語</label>
-          <input type="radio" id="zh_tw" name="font" value="zh_tw" checked>
+          <input type="radio" id="zh_tw" name="font" value="zh-Hant" checked>
           <label for="cn">繁體中文</label>
-          <input type="radio" id="zh_cn" name="font" value="zh_cn">
+          <input type="radio" id="zh_cn" name="font" value="zh-Hans">
           <label for="cn">简体中文</label>
         </div>
 
@@ -225,10 +225,10 @@
     角色/圖像均為Cygames/任天堂所有 /
     <a href="https://github.com/chaosspam/DLDialogueScreenGenerator">Github</a>
     /
-    <a href="/DLDialogueScreenGenerator/">English</a>
-    <a href="/DLDialogueScreenGenerator/jp.html">日本語</a>
-    <a href="/DLDialogueScreenGenerator/zh_tw.html">繁體中文</a>
-    <a href="/DLDialogueScreenGenerator/zh_cn.html">简体中文</a>
+    <a href="index.html">English</a>
+    <a href="jp.html">日本語</a>
+    <a href="zh_tw.html">繁體中文</a>
+    <a href="zh_cn.html">简体中文</a>
     <a href='https://ko-fi.com/N4N34N2U2' target='_blank'><img height='36' style='border:0px;height:24px;vertical-align:sub;' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
   </footer>
   <div id="deletePrompt" class="hidden">

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -33,7 +33,7 @@
 </head>
 <body>
   <h1>龍絆對話畫面生成器</h1>
-  <canvas id="preview" width="250px" height="445px"></canvas>
+  <canvas id="preview" width="250" height="445"></canvas>
   <section>
       <div id="uploadArea" class="settings">
 
@@ -220,7 +220,7 @@
 
       </div>
   </section>
-  <canvas id="editor" width="750px" height="1334px" class="hidden"></canvas>
+  <canvas id="editor" width="750" height="1334" class="hidden"></canvas>
   <footer>
     角色/圖像均為Cygames/任天堂所有 /
     <a href="https://github.com/chaosspam/DLDialogueScreenGenerator">Github</a>

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -145,19 +145,19 @@
 
         <div>
           <label>對話類型</label>
-          <input type="radio" name="stdialogue" value="dialogue" checked>
-          <label>一般</label>
-          <input type="radio" name="stdialogue" value="intro">
-          <label>進場</label>
-          <input type="radio" name="stdialogue" value="caption">
-          <label>標題</label>
+          <input type="radio" name="stdialogue" value="dialogue" id="std-dialogue" checked>
+          <label for="std-dialogue">一般</label>
+          <input type="radio" name="stdialogue" value="intro" id="std-intro">
+          <label for="std-intro">進場</label>
+          <input type="radio" name="stdialogue" value="caption" id="std-caption">
+          <label for="std-caption">標題</label>
           <br>
-          <input type="radio" name="stdialogue" value="full">
-          <label>全螢幕</label>
-          <input type="radio" name="stdialogue" value="narration">
-          <label>敘述</label>
-          <input type="radio" name="stdialogue" value="book">
-          <label>書</label>
+          <input type="radio" name="stdialogue" value="full" id="std-full">
+          <label for="std-full">全螢幕</label>
+          <input type="radio" name="stdialogue" value="narration" id="std-narration">
+          <label for="std-narration">敘述</label>
+          <input type="radio" name="stdialogue" value="book" id="std-book">
+          <label for="std-book">書</label>
         </div>
 
         <div>

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -145,18 +145,18 @@
 
         <div>
           <label>對話類型</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="dialogue" checked>
+          <input type="radio" name="stdialogue" value="dialogue" checked>
           <label>一般</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="intro">
+          <input type="radio" name="stdialogue" value="intro">
           <label>進場</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="caption">
+          <input type="radio" name="stdialogue" value="caption">
           <label>標題</label>
           <br>
-          <input type="radio" autocomplete="off" name="stdialogue" value="full">
+          <input type="radio" name="stdialogue" value="full">
           <label>全螢幕</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="narration">
+          <input type="radio" name="stdialogue" value="narration">
           <label>敘述</label>
-          <input type="radio" autocomplete="off" name="stdialogue" value="book">
+          <input type="radio" name="stdialogue" value="book">
           <label>書</label>
         </div>
 
@@ -167,9 +167,9 @@
           <input type="radio" id="jp" name="font" value="ja">
           <label for="jp">日本語</label>
           <input type="radio" id="zh_tw" name="font" value="zh-Hant" checked>
-          <label for="cn">繁體中文</label>
+          <label for="zh_tw">繁體中文</label>
           <input type="radio" id="zh_cn" name="font" value="zh-Hans">
-          <label for="cn">简体中文</label>
+          <label for="zh_cn">简体中文</label>
         </div>
 
         <div>


### PR DESCRIPTION
Fixes a handful of validation issues - bad lang attributes, deprecated attributes, etc.

Still has one validation error relating the the character reference in the textarea's example message. One solution is probably something like:
```html
    ...
    <textarea>blah blah blah
blah blah blah</textarea>
```
but the indentation is slightly gross.

<img width="571" alt="Screen Shot 2021-11-24 at 2 09 50 AM" src="https://user-images.githubusercontent.com/6354860/143218296-b4319987-473a-4d19-a171-e4f25fc0ecd0.png">